### PR TITLE
feat: CBT 2026 launch - marketing, registration, and SEO

### DIFF
--- a/app/tournaments/cherry-blossom/[year]/page.tsx
+++ b/app/tournaments/cherry-blossom/[year]/page.tsx
@@ -4,59 +4,52 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { Calendar, MapPin, Camera, Trophy, Users, ArrowLeft } from '@phosphor-icons/react';
+import { Calendar, MapPin, Camera, Trophy, Users, ArrowLeft, Clock, CheckCircle, Ticket } from '@phosphor-icons/react';
 import TournamentRegistration from '@/components/feature/tournament/TournamentRegistration';
-import TournamentRegisterButton from '@/components/feature/tournament/TournamentRegisterButton';
+import { getTournamentByYear, getHistoricalTournaments } from '@/data/cherry-blossom-tournaments';
+import { ZEFFY_LINKS } from '@/data/zeffy-links';
 
-interface TournamentDetails {
-  year: number;
-  date: string;
-  location: {
-    name: string;
-    address: string;
+export default function CherryBlossomYearPage({ params }: { params: { year: string } }) {
+  const yearNum = parseInt(params.year);
+  const tournament = getTournamentByYear(yearNum);
+  const historicalTournaments = getHistoricalTournaments();
+  const lastTournament = historicalTournaments[0];
+  
+  // Default data for 2026 if not found
+  const tournamentData = tournament || {
+    year: 2026,
+    edition: 58,
+    date: 'April 11-12, 2026',
+    datePending: false,
+    status: 'upcoming' as const,
+    location: {
+      name: 'Liberty Sports Park',
+      address: '220 Prince George\'s Boulevard, Upper Marlboro, MD 20774'
+    },
+    divisions: [
+      { name: 'Senior Men\'s 15s', description: 'Premier division for club teams', fee: 400, format: '15s' as const, maxTeams: 12 },
+      { name: 'Senior Women\'s 15s', description: 'Premier women\'s division', fee: 400, format: '15s' as const, maxTeams: 8 },
+      { name: 'Collegiate Men\'s 7s', description: 'CRC Qualifier', fee: 400, format: '7s' as const, maxTeams: 12 },
+      { name: 'Collegiate Women\'s 7s', description: 'CRC Qualifier', fee: 400, format: '7s' as const, maxTeams: 12 },
+      { name: 'High School Boy\'s 15s', description: 'Youth competition', fee: 350, format: '15s' as const, maxTeams: 8 },
+      { name: 'High School Girl\'s 15s', description: 'Youth women\'s competition', fee: 350, format: '15s' as const, maxTeams: 8 },
+      { name: 'Old Boy\'s 15s', description: 'Veterans division', fee: 350, format: '15s' as const, maxTeams: 8 }
+    ],
+    registrationOpen: true,
+    registrationOpens: 'December 1, 2025',
+    registrationCloses: 'April 1, 2026',
+    paymentDeadlineDays: 14,
+    highlights: ['58th Annual Cherry Blossom Tournament', 'Premier East Coast spring rugby event']
   };
-  divisions: {
-    name: string;
-    description?: string;
-    fee: number;
-  }[];
-  coverImage: string;
-  galleryImages: string[];
-  previousYear?: {
-    featuredTeams: string[];
-    totalTeams: number;
-    results: {
-      division: string;
-      champion: string;
-      runnerUp: string;
-    }[];
-  };
-}
 
-// This would eventually come from a database or CMS
-const tournamentDetails: TournamentDetails = {
-  year: 2025,
-  date: 'April 12-13, 2025',
-  location: {
-    name: 'Liberty Sports Park',
-    address: '220 Prince George\'s Boulevard Upper Marlboro, MD 20774'
-  },
-  divisions: [
-    { name: 'Senior Men\'s 15s', description: 'Premier division for club teams', fee: 400 },
-    { name: 'Collegiate Men\'s 7s', description: 'CRC Qualifier', fee: 400 },
-    { name: 'Collegiate Women\'s 7s', description: 'CRC Qualifier', fee: 400 },
-    { name: 'High School Boy\'s 15s', description: 'Youth competition', fee: 350 },
-    { name: 'High School Girl\'s 15s', description: 'Youth women\'s competition', fee: 350 },
-    { name: 'Senior Women\'s 15s', description: 'Premier women\'s division for club teams', fee: 400 },
-    { name: 'Old Boy\'s 15s', description: 'Veterans division', fee: 350 }
-  ],
-  coverImage: '/assets/pictures/2025_irish_ruck.jpg',
-  galleryImages: [
+  const coverImage = '/assets/pictures/2025_irish_ruck.jpg';
+  const galleryImages = [
     '/assets/pictures/2025_irish_ruck.jpg',
     '/assets/pictures/huddle_2025_irish.jpg',
     '/assets/pictures/2025_irish_harry.jpg'
-  ],
-  previousYear: {
+  ];
+
+  const previousYearData = {
     featuredTeams: [
       'Washington Irish',
       'New York Reds',
@@ -74,17 +67,18 @@ const tournamentDetails: TournamentDetails = {
       { division: 'Senior Men\'s 15s', champion: 'White Plains', runnerUp: 'New York Reds' },
       { division: 'Collegiate Men\'s 7s', champion: 'Kutztown', runnerUp: 'St. Bonnaventure' }
     ]
-  }
-};
+  };
 
-export default function CherryBlossomYearPage({ params }: { params: { year: string } }) {
+  const isUpcoming = tournamentData.status === 'upcoming';
+  const registrationLink = yearNum === 2026 ? ZEFFY_LINKS.cherryBlossom2026.registration : ZEFFY_LINKS.cherryBlossom.registration;
+
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900">
       {/* Hero Section */}
       <section className="relative h-[60vh] flex items-center justify-center">
         <div className="absolute inset-0 z-0">
           <Image
-            src={tournamentDetails.coverImage}
+            src={coverImage}
             alt={`Cherry Blossom Tournament ${params.year}`}
             fill
             className="object-cover brightness-75"
@@ -93,23 +87,39 @@ export default function CherryBlossomYearPage({ params }: { params: { year: stri
           <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-transparent" />
         </div>
         <div className="relative z-10 container mx-auto px-4 text-center text-white">
-          <h1 className="text-5xl md:text-7xl font-bold mb-4 ">
+          {isUpcoming && (
+            <div className="inline-flex items-center gap-2 bg-wrfc-red/90 text-white px-4 py-2 rounded-full text-sm font-semibold mb-4">
+              <CheckCircle className="w-4 h-4" />
+              Registration Now Open
+            </div>
+          )}
+          <h1 className="text-5xl md:text-7xl font-bold mb-4">
             Cherry Blossom Tournament
           </h1>
-          <p className="text-xl md:text-3xl mb-6 font-quantico">
-            {params.year} Edition
+          <p className="text-xl md:text-3xl mb-2 font-quantico">
+            {tournamentData.edition ? `${getOrdinalSuffix(tournamentData.edition)} Annual` : ''} {params.year} Edition
           </p>
-          <div className="flex items-center justify-center gap-8 mb-8 text-lg">
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-8 mb-8 text-lg">
             <div className="flex items-center gap-2">
               <Calendar className="w-5 h-5" />
-              <span>{tournamentDetails.date}</span>
+              <span>{tournamentData.date}</span>
             </div>
             <div className="flex items-center gap-2">
               <MapPin className="w-5 h-5" />
-              <span>{tournamentDetails.location.name}</span>
+              <span>{tournamentData.location.name}</span>
             </div>
           </div>
-          <TournamentRegisterButton year={params.year} />
+          {isUpcoming && tournamentData.registrationOpen && (
+            <a
+              href={registrationLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 bg-wrfc-red hover:bg-red-700 text-white px-8 py-4 rounded-lg font-bold text-lg transition-all duration-300 transform hover:scale-105 hover:shadow-xl"
+            >
+              <Ticket className="w-5 h-5" />
+              Register Your Team Now
+            </a>
+          )}
         </div>
       </section>
 
@@ -138,72 +148,144 @@ export default function CherryBlossomYearPage({ params }: { params: { year: stri
                 href="#past-results"
                 className="text-gray-600 dark:text-gray-100 hover:text-wrfc-navy dark:hover:text-blue-400"
               >
-                Last CBT Results
+                Past Results
               </Link>
             </div>
           </div>
         </div>
       </nav>
 
+      {/* Registration CTA Banner */}
+      {isUpcoming && tournamentData.registrationOpen && (
+        <div className="bg-gradient-to-r from-wrfc-navy to-blue-800 text-white py-4">
+          <div className="container mx-auto px-4">
+            <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+              <div className="flex items-center gap-4">
+                <Clock className="w-6 h-6 text-yellow-400" />
+                <div>
+                  <p className="font-semibold">Early Bird Registration Open!</p>
+                  <p className="text-sm text-blue-200">Registration closes {tournamentData.registrationCloses}</p>
+                </div>
+              </div>
+              <a
+                href={registrationLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-wrfc-red hover:bg-red-700 text-white px-6 py-2 rounded-lg font-semibold transition-colors"
+              >
+                Register Now
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Main Content */}
       <div className="container mx-auto px-4 py-16">
+        {/* Tournament Highlights */}
+        {tournamentData.highlights && tournamentData.highlights.length > 0 && (
+          <div className="mb-12">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              {tournamentData.highlights.map((highlight, index) => (
+                <div key={index} className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 text-center">
+                  <CheckCircle className="w-6 h-6 text-wrfc-red mx-auto mb-2" />
+                  <p className="text-sm font-medium">{highlight}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
         <div className="grid md:grid-cols-2 gap-8">
           {/* Tournament Details Card */}
           <Card className="p-8">
-            <h2 className="text-3xl font-bold mb-6  text-wrfc-navy dark:text-blue-400">
+            <h2 className="text-3xl font-bold mb-6 text-wrfc-navy dark:text-blue-400">
               Tournament Details
             </h2>
             <div className="space-y-6">
               <div className="flex items-start gap-4">
+                <Calendar className="w-6 h-6 text-wrfc-red shrink-0" />
+                <div>
+                  <h3 className="font-bold mb-1">Date</h3>
+                  <p>{tournamentData.date}</p>
+                  {tournamentData.registrationCloses && (
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                      Registration closes: {tournamentData.registrationCloses}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-start gap-4">
                 <MapPin className="w-6 h-6 text-wrfc-red shrink-0" />
                 <div>
                   <h3 className="font-bold mb-1">Location</h3>
-                  <p>{tournamentDetails.location.name}</p>
+                  <p>{tournamentData.location.name}</p>
                   <p className="text-sm text-gray-600 dark:text-gray-100">
-                    {tournamentDetails.location.address}
+                    {tournamentData.location.address}
                   </p>
+                  <a 
+                    href={`https://maps.google.com/?q=${encodeURIComponent(tournamentData.location.address)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-wrfc-red hover:underline mt-1 inline-block"
+                  >
+                    Get Directions
+                  </a>
                 </div>
               </div>
               <div className="flex items-start gap-4">
                 <Users className="w-6 h-6 text-wrfc-red shrink-0" />
-                <div>
+                <div className="w-full">
                   <h3 className="font-bold mb-2">Divisions & Entry Fees</h3>
                   <div className="space-y-3">
-                    {tournamentDetails.divisions.map((division) => (
+                    {tournamentData.divisions.map((division) => (
                       <div key={division.name} className="flex items-center justify-between">
                         <div className="flex items-center">
                           <span className="w-2 h-2 bg-wrfc-red rounded-full mr-2" />
-                          <span>{division.name}</span>
+                          <div>
+                            <span className="font-medium">{division.name}</span>
+                            {division.description && (
+                              <p className="text-xs text-gray-500">{division.description}</p>
+                            )}
+                          </div>
                         </div>
                         <span className="font-semibold">${division.fee}</span>
                       </div>
                     ))}
                   </div>
-                  <div className="mt-8">
-                    <TournamentRegistration divisions={tournamentDetails.divisions} />
-                  </div>
+                  {isUpcoming && tournamentData.registrationOpen && (
+                    <div className="mt-8">
+                      <TournamentRegistration 
+                        divisions={tournamentData.divisions.map(d => ({
+                          name: d.name,
+                          description: d.description,
+                          fee: d.fee
+                        }))} 
+                      />
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
           </Card>
 
           {/* Past Results Card */}
-          <Card className="p-8">
-            <h2 className="text-3xl font-bold mb-6  text-wrfc-navy dark:text-blue-400">
-              Last CBT Results
+          <Card className="p-8" id="past-results">
+            <h2 className="text-3xl font-bold mb-6 text-wrfc-navy dark:text-blue-400">
+              {lastTournament ? `${lastTournament.year} Results` : 'Past Results'}
             </h2>
             <div className="space-y-6">
-              {tournamentDetails.previousYear?.results.map((result) => (
+              {previousYearData.results.map((result) => (
                 <div key={result.division} className="border-b border-gray-200 dark:border-gray-700 pb-4">
                   <h3 className="font-bold mb-2">{result.division}</h3>
                   <div className="space-y-1 text-sm">
                     <div className="flex items-center gap-2">
-                      <Trophy className="w-4 h-4 text-wrfc-red" />
+                      <Trophy className="w-4 h-4 text-yellow-500" />
                       <span className="font-semibold">Champion:</span>
                       <span>{result.champion}</span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <span className="w-4 h-4" /> {/* Spacer */}
+                      <span className="w-4 h-4" />
                       <span className="font-semibold">Runner-up:</span>
                       <span>{result.runnerUp}</span>
                     </div>
@@ -211,23 +293,21 @@ export default function CherryBlossomYearPage({ params }: { params: { year: stri
                 </div>
               ))}
               <div>
-                <h3 className="font-bold mb-3">Last Year&apos;s Teams</h3>
+                <h3 className="font-bold mb-3">Participating Teams</h3>
                 <div className="space-y-2">
                   <div className="flex flex-wrap gap-2">
-                    {tournamentDetails.previousYear?.featuredTeams.map((team) => (
+                    {previousYearData.featuredTeams.map((team) => (
                       <span 
                         key={team} 
-                        className="inline-flex items-center bg-gray-100 dark:bg-gray-900 rounded-full px-3 py-1 text-sm"
+                        className="inline-flex items-center bg-gray-100 dark:bg-gray-800 rounded-full px-3 py-1 text-sm"
                       >
                         {team}
                       </span>
                     ))}
                   </div>
-                  {tournamentDetails.previousYear && (
-                    <p className="text-sm text-gray-600 dark:text-gray-100 mt-2">
-                      + {tournamentDetails.previousYear.totalTeams - tournamentDetails.previousYear.featuredTeams.length} other teams
-                    </p>
-                  )}
+                  <p className="text-sm text-gray-600 dark:text-gray-100 mt-2">
+                    + {previousYearData.totalTeams - previousYearData.featuredTeams.length} other teams
+                  </p>
                 </div>
               </div>
             </div>
@@ -237,7 +317,7 @@ export default function CherryBlossomYearPage({ params }: { params: { year: stri
         {/* Photo Highlights */}
         <div className="mt-16">
           <div className="flex items-center justify-between mb-8">
-            <h2 className="text-3xl font-bold  text-wrfc-navy dark:text-blue-400">
+            <h2 className="text-3xl font-bold text-wrfc-navy dark:text-blue-400">
               Photo Highlights
             </h2>
             <Link href={`/tournaments/cherry-blossom/${params.year}/photos`}>
@@ -248,7 +328,7 @@ export default function CherryBlossomYearPage({ params }: { params: { year: stri
             </Link>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {tournamentDetails.galleryImages.map((image, index) => (
+            {galleryImages.map((image, index) => (
               <div key={index} className="relative aspect-video rounded-lg overflow-hidden">
                 <Image
                   src={image}
@@ -260,7 +340,33 @@ export default function CherryBlossomYearPage({ params }: { params: { year: stri
             ))}
           </div>
         </div>
+
+        {/* Final CTA */}
+        {isUpcoming && tournamentData.registrationOpen && (
+          <div className="mt-16 bg-gradient-to-r from-wrfc-red to-red-700 rounded-xl p-8 text-center text-white">
+            <h2 className="text-3xl font-bold mb-4">Ready to Compete?</h2>
+            <p className="text-lg mb-6 max-w-2xl mx-auto">
+              Don&apos;t miss your chance to be part of the {tournamentData.edition ? `${getOrdinalSuffix(tournamentData.edition)} Annual` : ''} Cherry Blossom Tournament. 
+              Register your team today!
+            </p>
+            <a
+              href={registrationLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 bg-white text-wrfc-red hover:bg-gray-100 px-8 py-4 rounded-lg font-bold text-lg transition-all duration-300 transform hover:scale-105"
+            >
+              <Ticket className="w-5 h-5" />
+              Register Now - Starting at $350
+            </a>
+          </div>
+        )}
       </div>
     </div>
   );
-} 
+}
+
+function getOrdinalSuffix(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}

--- a/app/tournaments/cherry-blossom/page.tsx
+++ b/app/tournaments/cherry-blossom/page.tsx
@@ -1,5 +1,17 @@
 import { redirect } from 'next/navigation';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Cherry Blossom Tournament 2026 | Washington Rugby Football Club',
+  description: 'Register for the 58th Annual Cherry Blossom Rugby Tournament in Washington DC. April 11-12, 2026 at Liberty Sports Park. Multiple divisions for men\'s, women\'s, collegiate, and high school teams.',
+  keywords: ['Cherry Blossom Tournament', 'rugby tournament', 'Washington DC rugby', 'WRFC', '2026 rugby', 'collegiate rugby', 'spring rugby tournament'],
+  openGraph: {
+    title: 'Cherry Blossom Tournament 2026',
+    description: 'Premier East Coast rugby tournament. April 11-12, 2026 in Washington DC.',
+    images: ['/assets/pictures/tournament_banner_watercolor.png'],
+  },
+};
 
 export default function CherryBlossomTournament() {
-  redirect('/tournaments/cherry-blossom/2025');
+  redirect('/tournaments/cherry-blossom/2026');
 } 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -83,6 +83,7 @@ const NAV_LINKS: NavLink[] = [
   { href: '/tournaments', label: 'Tournaments' },
   { href: '/alumni', label: 'Alumni' },
   { href: '/sponsors', label: 'Sponsors' },
+  { href: '/donate', label: 'Donate', highlight: true },
   { href: '/contact', label: 'Contact' },
   { href: 'https://www.zeffy.com/ticketing/wrfc-player-dues', label: 'Pay Dues', external: true, highlight: true, isZeffy: true },
 ]

--- a/data/cherry-blossom-tournaments.ts
+++ b/data/cherry-blossom-tournaments.ts
@@ -44,54 +44,74 @@ export const cherryBlossomTournaments: TournamentYear[] = [
   {
     year: 2026,
     edition: 58,
-    date: 'TBD',
-    datePending: true,
+    date: 'April 11-12, 2026',
+    datePending: false,
     status: 'upcoming',
     location: {
-      name: 'TBD',
-      address: 'Location to be announced'
+      name: 'Liberty Sports Park',
+      address: '220 Prince George\'s Boulevard, Upper Marlboro, MD 20774'
     },
     divisions: [
       {
-        name: 'Men\'s Club',
+        name: 'Senior Men\'s 15s',
         description: 'Premier division for men\'s club teams',
         fee: 400,
         format: '15s',
         maxTeams: 12
       },
       {
-        name: 'Women\'s College',
-        description: 'Collegiate women\'s division',
+        name: 'Senior Women\'s 15s',
+        description: 'Premier women\'s division for club teams',
         fee: 400,
         format: '15s',
         maxTeams: 8
       },
       {
-        name: 'Men\'s College',
-        description: 'Collegiate men\'s division',
+        name: 'Collegiate Men\'s 7s',
+        description: 'CRC Qualifier - Collegiate men\'s division',
         fee: 400,
-        format: '15s',
-        maxTeams: 8
+        format: '7s',
+        maxTeams: 12
       },
       {
-        name: 'Old Boys 15s',
-        description: 'Veterans division for men 35+',
+        name: 'Collegiate Women\'s 7s',
+        description: 'CRC Qualifier - Collegiate women\'s division',
+        fee: 400,
+        format: '7s',
+        maxTeams: 12
+      },
+      {
+        name: 'High School Boy\'s 15s',
+        description: 'Youth competition for high school boys',
         fee: 350,
         format: '15s',
         maxTeams: 8
       },
       {
-        name: 'U18/College Boys',
-        description: 'Youth competition for high school and college boys',
+        name: 'High School Girl\'s 15s',
+        description: 'Youth competition for high school girls',
+        fee: 350,
+        format: '15s',
+        maxTeams: 8
+      },
+      {
+        name: 'Old Boy\'s 15s',
+        description: 'Veterans division for men 35+',
         fee: 350,
         format: '15s',
         maxTeams: 8
       }
     ],
-    registrationOpen: true, // Testing enabled - set to false before production
-    registrationOpens: 'November 15, 2025',
-    registrationCloses: 'April 22, 2026',
-    paymentDeadlineDays: 14
+    registrationOpen: true,
+    registrationOpens: 'December 1, 2025',
+    registrationCloses: 'April 1, 2026',
+    paymentDeadlineDays: 14,
+    highlights: [
+      '58th Annual Cherry Blossom Tournament',
+      'Premier East Coast spring rugby event',
+      '7 divisions across all levels of play',
+      'CRC Qualifier for collegiate 7s'
+    ]
   },
   {
     year: 2025,

--- a/data/promotions/cherry-blossom.ts
+++ b/data/promotions/cherry-blossom.ts
@@ -2,38 +2,42 @@ import { Promotion } from './index';
 import { ZEFFY_LINKS } from '@/data/zeffy-links';
 
 export const cherryBlossomPromotion: Promotion = {
-  id: 'cherry-blossom-2025',
-  title: 'Cherry Blossom Tournament 2025',
-  description: 'Join us for the annual Cherry Blossom Rugby Tournament in Washington DC. Multiple divisions available for men\'s and women\'s teams.',
+  id: 'cherry-blossom-2026',
+  title: 'Cherry Blossom Tournament 2026',
+  description: 'Join us for the 2026 Cherry Blossom Rugby Tournament in Washington DC. Register your team now for this premier East Coast rugby event!',
   imageUrl: '/assets/pictures/tournament_banner_watercolor.png',
-  buttonText: 'Register Now',
-  buttonUrl: ZEFFY_LINKS.cherryBlossom.registration,
-  startDate: '2025-01-01T00:00:00Z',
-  endDate: '2025-04-10T23:59:59Z',
+  buttonText: 'Register Your Team',
+  buttonUrl: ZEFFY_LINKS.cherryBlossom2026.registration,
+  startDate: '2025-12-01T00:00:00Z',
+  endDate: '2026-04-10T23:59:59Z',
   priority: 100,
-  isActive: false,
+  isActive: true,
   type: 'tournament',
-  tags: ['rugby', 'tournament', 'cherry blossom', '2025'],
+  tags: ['rugby', 'tournament', 'cherry blossom', '2026', 'DC'],
   ctaType: 'external',
   modalContent: {
-    title: 'Cherry Blossom Tournament 2025',
+    title: 'Cherry Blossom Tournament 2026',
     content: `
-      <p>The Washington Rugby Football Club is proud to host the annual Cherry Blossom Tournament on April 12-13, 2025.</p>
+      <p class="text-lg mb-4">The Washington Rugby Football Club is proud to host the annual Cherry Blossom Tournament - one of the premier rugby events on the East Coast!</p>
       
-      <h3>Divisions</h3>
-      <ul>
+      <h3 class="text-xl font-bold mb-2 text-wrfc-red">Tournament Details</h3>
+      <p class="mb-4"><strong>Date:</strong> April 11-12, 2026</p>
+      <p class="mb-4"><strong>Location:</strong> Liberty Sports Park, 220 Prince George's Boulevard, Upper Marlboro, MD 20774</p>
+      
+      <h3 class="text-xl font-bold mb-2 text-wrfc-red">Divisions & Entry Fees</h3>
+      <ul class="list-disc pl-5 mb-4 space-y-1">
         <li>Senior Men's 15s - $400</li>
+        <li>Senior Women's 15s - $400</li>
         <li>Collegiate Men's 7s - $400</li>
         <li>Collegiate Women's 7s - $400</li>
         <li>High School Boy's 15s - $350</li>
         <li>High School Girl's 15s - $350</li>
-        <li>Senior Women's 15s - $400</li>
         <li>Old Boy's 15s - $350</li>
       </ul>
       
-      <p class="text-center font-bold">Location: Liberty Sports Park, 220 Prince George's Boulevard Upper Marlboro, MD 20774</p>
+      <p class="text-center font-bold text-lg bg-gray-100 dark:bg-gray-800 p-4 rounded-lg">Early Bird Registration Now Open!</p>
       
-      <p>Register your team today to secure your spot in this premier rugby event!</p>
+      <p class="mt-4">Don't miss your chance to compete in DC's premier spring rugby tournament. Register your team today!</p>
     `,
     imageUrl: '/assets/pictures/tournament_banner_watercolor.png'
   }

--- a/data/zeffy-links.ts
+++ b/data/zeffy-links.ts
@@ -3,8 +3,12 @@
 
 export const ZEFFY_LINKS = {
   cherryBlossom: {
-    registration: 'https://www.zeffy.com/en-US/ticketing/your-cherry-blossom-link', // TODO: Replace with actual Zeffy link
+    registration: 'https://www.zeffy.com/en-US/ticketing/cherry-blossom-tournament--2026',
     description: 'Cherry Blossom Tournament Registration'
+  },
+  cherryBlossom2026: {
+    registration: 'https://www.zeffy.com/en-US/ticketing/cherry-blossom-tournament--2026',
+    description: 'Cherry Blossom Tournament 2026 Registration'
   },
   membership: {
     full: 'https://www.zeffy.com/en-US/membership/your-full-membership-link', // TODO: Replace with actual Zeffy link


### PR DESCRIPTION
- Add Donate link back to navigation header
- Update Cherry Blossom Tournament for 2026:
  - New Zeffy registration link for 2026
  - Updated tournament dates: April 11-12, 2026
  - 7 divisions with proper pricing
  - Location: Liberty Sports Park
- Enable CBT 2026 marketing modal promotion (isActive: true)
- Enhanced CBT page with:
  - Registration open banner
  - Early bird CTA sections
  - Improved division display with descriptions
  - Direct registration buttons
  - SEO metadata for tournament
- Redirect /tournaments/cherry-blossom to 2026 edition