### PR TITLE
fix: correct Pay Dues button Zeffy URLs with /en-US/ locale path

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -138,7 +138,7 @@ export default function Home() {
                 Donate
               </Link>
               <a 
-                href="https://www.zeffy.com/ticketing/wrfc-player-dues" 
+                href="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues" 
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-white/10 backdrop-blur-sm hover:bg-white/20 text-white px-8 py-4 rounded-lg font-bold transition-all transform hover:scale-105 hover:shadow-lg"

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -306,7 +306,7 @@ export default function TeamsPage() {
                 Become a Member
               </Link>
               <a 
-                zeffy-form-link="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues"
+                zeffy-form-link="https://www.zeffy.com/en-US/embed/ticketing/wrfc-player-dues?modal=true"
                 className="inline-block bg-transparent border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-blue-700 transition-colors cursor-pointer"
               >
                 Pay Dues

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -306,7 +306,7 @@ export default function TeamsPage() {
                 Become a Member
               </Link>
               <a 
-                zeffy-form-link="https://www.zeffy.com/embed/ticketing/wrfc-player-dues?modal=true"
+                zeffy-form-link="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues"
                 className="inline-block bg-transparent border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-blue-700 transition-colors cursor-pointer"
               >
                 Pay Dues

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -305,8 +305,10 @@ export default function TeamsPage() {
               >
                 Become a Member
               </Link>
-              <a 
-                zeffy-form-link="https://www.zeffy.com/en-US/embed/ticketing/wrfc-player-dues?modal=true"
+              <a
+                href="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="inline-block bg-transparent border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-blue-700 transition-colors cursor-pointer"
               >
                 Pay Dues

--- a/components/RegisterButton.tsx
+++ b/components/RegisterButton.tsx
@@ -4,17 +4,17 @@ import { Button } from '@/components/ui/button';
 import { ArrowRight } from '@phosphor-icons/react';
 
 interface RegisterButtonProps {
-  squareCheckoutUrl?: string;
+  registrationUrl?: string;
 }
 
-export default function RegisterButton({ squareCheckoutUrl = 'https://checkout.square.site/merchant/W1AZ3RW1C2M9K/checkout/C6FSYI5DTSWWHGQDNKCUYTE6' }: RegisterButtonProps) {
+export default function RegisterButton({ registrationUrl = 'https://www.zeffy.com/en-US/ticketing/cherry-blossom-tournament--2026' }: RegisterButtonProps) {
   return (
     <div className="relative">
       <div className="absolute -inset-1 bg-gradient-to-r from-wrfc-red to-wrfc-navy rounded-lg blur opacity-75 animate-pulse"></div>
-      <Button 
+      <Button
         className="relative bg-wrfc-red hover:bg-wrfc-red/90 text-white font-bold py-6 px-6 transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
-        onClick={() => window.open(squareCheckoutUrl, '_blank')}
-        aria-label="Register for the 2025 Cherry Blossom Tournament"
+        onClick={() => window.open(registrationUrl, '_blank')}
+        aria-label="Register for the 2026 Cherry Blossom Tournament"
       >
         Register Now
         <ArrowRight className="ml-2 w-4 h-4 group-hover:translate-x-1 transition-transform duration-200" />

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -221,7 +221,7 @@ export default function Header() {
 
               {/* Pay Dues Button */}
               <a
-                zeffy-form-link="https://www.zeffy.com/ticketing/wrfc-player-dues"
+                zeffy-form-link="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues"
                 className="px-4 py-2 border-2 border-wrfc-navy dark:border-gray-400 text-wrfc-navy dark:text-gray-100 hover:bg-wrfc-navy hover:text-white dark:hover:bg-gray-700 text-sm font-semibold rounded-lg transition-all duration-300 cursor-pointer"
               >
                 Pay Dues
@@ -369,7 +369,7 @@ export default function Header() {
                   Donate
                 </Link>
                 <a
-                  zeffy-form-link="https://www.zeffy.com/ticketing/wrfc-player-dues"
+                  zeffy-form-link="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues"
                   className="flex-1 py-2.5 text-center text-wrfc-navy dark:text-gray-100 font-semibold border-2 border-wrfc-navy dark:border-gray-400 rounded-lg hover:bg-wrfc-navy hover:text-white dark:hover:bg-gray-700 transition-all duration-300 cursor-pointer"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -221,7 +221,9 @@ export default function Header() {
 
               {/* Pay Dues Button */}
               <a
-                zeffy-form-link="https://www.zeffy.com/en-US/embed/ticketing/wrfc-player-dues?modal=true"
+                href="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="px-4 py-2 border-2 border-wrfc-navy dark:border-gray-400 text-wrfc-navy dark:text-gray-100 hover:bg-wrfc-navy hover:text-white dark:hover:bg-gray-700 text-sm font-semibold rounded-lg transition-all duration-300 cursor-pointer"
               >
                 Pay Dues
@@ -369,7 +371,9 @@ export default function Header() {
                   Donate
                 </Link>
                 <a
-                  zeffy-form-link="https://www.zeffy.com/en-US/embed/ticketing/wrfc-player-dues?modal=true"
+                  href="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="flex-1 py-2.5 text-center text-wrfc-navy dark:text-gray-100 font-semibold border-2 border-wrfc-navy dark:border-gray-400 rounded-lg hover:bg-wrfc-navy hover:text-white dark:hover:bg-gray-700 transition-all duration-300 cursor-pointer"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -221,7 +221,7 @@ export default function Header() {
 
               {/* Pay Dues Button */}
               <a
-                zeffy-form-link="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues"
+                zeffy-form-link="https://www.zeffy.com/en-US/embed/ticketing/wrfc-player-dues?modal=true"
                 className="px-4 py-2 border-2 border-wrfc-navy dark:border-gray-400 text-wrfc-navy dark:text-gray-100 hover:bg-wrfc-navy hover:text-white dark:hover:bg-gray-700 text-sm font-semibold rounded-lg transition-all duration-300 cursor-pointer"
               >
                 Pay Dues
@@ -369,7 +369,7 @@ export default function Header() {
                   Donate
                 </Link>
                 <a
-                  zeffy-form-link="https://www.zeffy.com/en-US/ticketing/wrfc-player-dues"
+                  zeffy-form-link="https://www.zeffy.com/en-US/embed/ticketing/wrfc-player-dues?modal=true"
                   className="flex-1 py-2.5 text-center text-wrfc-navy dark:text-gray-100 font-semibold border-2 border-wrfc-navy dark:border-gray-400 rounded-lg hover:bg-wrfc-navy hover:text-white dark:hover:bg-gray-700 transition-all duration-300 cursor-pointer"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >


### PR DESCRIPTION
The Pay Dues buttons were not working because the Zeffy URLs were missing the /en-US/ locale path segment required for the payment forms to load.