### PR TITLE
Update CBT 2026 tournament location to Aldie, VA

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -96,7 +96,7 @@ export default function Home() {
                   </div>
                   <div className="flex-grow text-center md:text-left">
                     <div className="flex items-center justify-center md:justify-start gap-2 mb-1">
-                      <span className="text-xs font-bold uppercase tracking-wider text-pink-300">We&apos;re Back in DC!</span>
+                      <span className="text-xs font-bold uppercase tracking-wider text-pink-300">58th Annual CBT in Aldie, VA!</span>
                     </div>
                     <h3 className="text-lg md:text-xl font-bold text-white mb-1">
                       58th Annual Cherry Blossom Tournament
@@ -108,7 +108,7 @@ export default function Home() {
                       </span>
                       <span className="flex items-center gap-1">
                         <MapPin className="w-4 h-4" />
-                        The Fields at RFK
+                        Aldie, VA
                       </span>
                     </div>
                   </div>

--- a/app/tournaments/cherry-blossom/[year]/page.tsx
+++ b/app/tournaments/cherry-blossom/[year]/page.tsx
@@ -22,8 +22,8 @@ export default function CherryBlossomYearPage({ params }: { params: { year: stri
     datePending: false,
     status: 'upcoming' as const,
     location: {
-      name: 'The Fields at RFK',
-      address: 'Washington, DC'
+      name: '22006 James Monroe Highway',
+      address: 'Aldie, VA 20105'
     },
     divisions: [
       { name: 'Club 15s', description: 'Men\'s & Women\'s Club teams', fee: 485, format: '15s' as const, maxTeams: 12 },
@@ -35,7 +35,7 @@ export default function CherryBlossomYearPage({ params }: { params: { year: stri
     registrationOpens: 'December 1, 2025',
     registrationCloses: 'April 1, 2026',
     paymentDeadlineDays: 14,
-    highlights: ['58th Annual Cherry Blossom Tournament', 'We\'re back in DC at The Fields at RFK!', 'Premier East Coast spring rugby event']
+    highlights: ['58th Annual Cherry Blossom Tournament', 'Join us in Aldie, VA!', 'Premier East Coast spring rugby event']
   };
 
   const isBackInDC = yearNum === 2026;
@@ -88,7 +88,7 @@ export default function CherryBlossomYearPage({ params }: { params: { year: stri
           {isBackInDC && (
             <div className="inline-flex items-center gap-2 bg-gradient-to-r from-wrfc-navy to-blue-700 text-white px-6 py-2 rounded-full text-sm font-bold mb-4 animate-pulse">
               <MapPin className="w-4 h-4" />
-              We&apos;re Back in DC!
+              Now in Aldie, VA!
             </div>
           )}
           {isUpcoming && (

--- a/app/tournaments/cherry-blossom/page.tsx
+++ b/app/tournaments/cherry-blossom/page.tsx
@@ -3,11 +3,11 @@ import { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'Cherry Blossom Tournament 2026 | Washington Rugby Football Club',
-  description: 'We\'re back in DC! Register for the 58th Annual Cherry Blossom Rugby Tournament. April 11, 2026 at The Fields at RFK in Washington DC. Multiple divisions for men\'s club, collegiate, and old boys teams.',
-  keywords: ['Cherry Blossom Tournament', 'rugby tournament', 'Washington DC rugby', 'WRFC', '2026 rugby', 'collegiate rugby', 'spring rugby tournament', 'RFK rugby', 'DC rugby tournament'],
+  description: 'Register for the 58th Annual Cherry Blossom Rugby Tournament. April 11, 2026 at 22006 James Monroe Highway, Aldie, VA 20105. Multiple divisions for men\'s club, collegiate, and old boys teams.',
+  keywords: ['Cherry Blossom Tournament', 'rugby tournament', 'Virginia rugby', 'WRFC', '2026 rugby', 'collegiate rugby', 'spring rugby tournament', 'Aldie VA rugby', 'rugby tournament'],
   openGraph: {
-    title: 'Cherry Blossom Tournament 2026 - We\'re Back in DC!',
-    description: '58th Annual Cherry Blossom Rugby Tournament. April 11, 2026 at The Fields at RFK, Washington DC.',
+    title: 'Cherry Blossom Tournament 2026',
+    description: '58th Annual Cherry Blossom Rugby Tournament. April 11, 2026 at 22006 James Monroe Highway, Aldie, VA 20105.',
     images: ['/assets/pictures/138A4076.jpg'],
   },
 };

--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -36,9 +36,9 @@ const tournaments: Tournament[] = [
     id: 'cherry-blossom',
     name: 'Cherry Blossom Tournament',
     date: 'April 11, 2026',
-    location: 'The Fields at RFK, Washington DC',
+    location: '22006 James Monroe Highway, Aldie, VA 20105',
     coverImage: '/assets/pictures/138A4076.jpg',
-    description: '58th Annual Cherry Blossom Tournament - We\'re back in DC! Join us at The Fields at RFK for the premier East Coast spring rugby event.',
+    description: '58th Annual Cherry Blossom Tournament - Join us in Aldie, VA for the premier East Coast spring rugby event.',
     divisions: [
       {
         id: 'club-2026',
@@ -332,7 +332,7 @@ export default async function TournamentsPage() {
                           </div>
                           {upcomingTournament.year === 2026 && (
                             <span className="inline-flex items-center gap-1 bg-gradient-to-r from-pink-500 to-wrfc-red text-white text-xs font-bold px-3 py-1 rounded-full">
-                              🌸 We&apos;re Back in DC!
+                              🌸 Now in Aldie, VA!
                             </span>
                           )}
                         </div>

--- a/components/feature/promotion/PromotionModal.tsx
+++ b/components/feature/promotion/PromotionModal.tsx
@@ -69,11 +69,11 @@ export default function PromotionModal({ promotion, isOpen, onClose }: Promotion
               <div className="flex flex-wrap gap-2 mb-4">
                 <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm">
                   <CalendarBlank className="w-4 h-4 text-pink-500" weight="duotone" />
-                  April 11-12, 2026
+                  April 11, 2026
                 </span>
                 <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm">
                   <MapPin className="w-4 h-4 text-pink-500" weight="duotone" />
-                  Liberty Sports Park, MD
+                  Aldie, VA 20105
                 </span>
               </div>
             )}

--- a/components/feature/promotion/WelcomeModal.tsx
+++ b/components/feature/promotion/WelcomeModal.tsx
@@ -110,7 +110,7 @@ export default function WelcomeModal() {
                   </span>
                   <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm">
                     <MapPin className="w-4 h-4 text-pink-500" weight="duotone" />
-                    The Fields at RFK, Washington DC
+                    Aldie, VA 20105
                   </span>
                 </div>
               )}

--- a/data/cherry-blossom-tournaments.ts
+++ b/data/cherry-blossom-tournaments.ts
@@ -48,8 +48,8 @@ export const cherryBlossomTournaments: TournamentYear[] = [
     datePending: false,
     status: 'upcoming',
     location: {
-      name: 'The Fields at RFK',
-      address: 'Washington, DC'
+      name: '22006 James Monroe Highway',
+      address: 'Aldie, VA 20105'
     },
     divisions: [
       {
@@ -87,7 +87,7 @@ export const cherryBlossomTournaments: TournamentYear[] = [
     paymentDeadlineDays: 14,
     highlights: [
       '58th Annual Cherry Blossom Tournament',
-      'We\'re back in DC at The Fields at RFK!',
+      'Join us in Aldie, VA!',
       'Premier East Coast spring rugby event',
       '5 divisions across all levels of play'
     ]

--- a/data/promotions/cherry-blossom.ts
+++ b/data/promotions/cherry-blossom.ts
@@ -4,7 +4,7 @@ import { ZEFFY_LINKS } from '@/data/zeffy-links';
 export const cherryBlossomPromotion: Promotion = {
   id: 'cherry-blossom-2026',
   title: 'Cherry Blossom Tournament 2026',
-  description: 'We\'re back in DC! The 58th Annual Cherry Blossom Rugby Tournament returns to The Fields at RFK on April 11, 2026.',
+  description: 'The 58th Annual Cherry Blossom Rugby Tournament is coming to Aldie, VA on April 11, 2026.',
   imageUrl: '/assets/pictures/138A4076.jpg',
   buttonText: 'Register Your Team',
   buttonUrl: ZEFFY_LINKS.cherryBlossom.registration,
@@ -13,16 +13,16 @@ export const cherryBlossomPromotion: Promotion = {
   priority: 100,
   isActive: true,
   type: 'tournament',
-  tags: ['rugby', 'tournament', 'cherry blossom', '2026', 'DC', 'RFK', 'washington dc'],
+  tags: ['rugby', 'tournament', 'cherry blossom', '2026', 'Aldie', 'Virginia', 'VA'],
   ctaType: 'external',
   modalContent: {
     title: 'Cherry Blossom Tournament 2026',
     content: `
-      <p class="text-lg mb-4"><strong>We're back in DC!</strong> The Washington Rugby Football Club is proud to host the 58th Annual Cherry Blossom Tournament - returning to the heart of the nation's capital!</p>
-      
+      <p class="text-lg mb-4">The Washington Rugby Football Club is proud to host the 58th Annual Cherry Blossom Tournament in Aldie, VA!</p>
+
       <h3 class="text-xl font-bold mb-2 text-wrfc-red">Tournament Details</h3>
       <p class="mb-4"><strong>Date:</strong> April 11, 2026</p>
-      <p class="mb-4"><strong>Location:</strong> The Fields at RFK, Washington DC</p>
+      <p class="mb-4"><strong>Location:</strong> 22006 James Monroe Highway, Aldie, VA 20105</p>
       
       <h3 class="text-xl font-bold mb-2 text-wrfc-red">15s Only - Men's & Women's</h3>
       <ul class="list-disc pl-5 mb-4 space-y-1">


### PR DESCRIPTION
Change venue from The Fields at RFK (Washington, DC) to 22006 James Monroe Highway, Aldie, VA 20105. Updated all location references, metadata, SEO copy, and promotional content across the site.